### PR TITLE
fix: support legacy memory field

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -20,6 +20,7 @@ import datetime
 import json
 import logging
 import uuid
+from typing import Optional
 
 from app.database import SessionLocal
 from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
@@ -59,7 +60,7 @@ mcp_router = APIRouter(prefix="/mcp")
 sse = SseServerTransport("/mcp/messages/")
 
 @mcp.tool(description="Add a new memory. This method is called everytime the user informs anything about themselves, their preferences, or anything that has any relevant information which can be useful in the future conversation. This can also be called when the user asks you to remember something.")
-async def add_memories(text: str) -> str:
+async def add_memories(text: Optional[str] = None, memory: Optional[str] = None) -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
 
@@ -67,6 +68,11 @@ async def add_memories(text: str) -> str:
         return "Error: user_id not provided"
     if not client_name:
         return "Error: client_name not provided"
+
+    if text is None and memory is None:
+        return "Error: text not provided"
+
+    text = text or memory
 
     # Get memory client safely
     memory_client = get_memory_client_safe()

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -20,7 +20,7 @@ from app.utils.permissions import check_memory_access_permissions
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate as sqlalchemy_paginate
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
@@ -201,10 +201,19 @@ async def get_categories(
 
 class CreateMemoryRequest(BaseModel):
     user_id: str
-    text: str
+    text: Optional[str] = None
+    memory: Optional[str] = None
     metadata: dict = {}
     infer: bool = True
     app: str = "openmemory"
+
+    @root_validator(pre=True)
+    def populate_text(cls, values):
+        text = values.get("text") or values.get("memory")
+        if text is None:
+            raise ValueError("Either 'text' or 'memory' field is required")
+        values["text"] = text
+        return values
 
 
 # Create new memory


### PR DESCRIPTION
## Summary
- allow `memory` field as alias for `text` when creating memories
- make MCP `add_memories` tool accept either `text` or `memory`

## Testing
- `pytest` *(fails: 102 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a2229e629c832dbfa569d8462684ee