### PR TITLE
fix: support legacy memory field

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -20,6 +20,7 @@ import datetime
 import json
 import logging
 import uuid
+from typing import Annotated
 
 from app.database import SessionLocal
 from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
@@ -31,6 +32,7 @@ from fastapi import FastAPI, Request
 from fastapi.routing import APIRouter
 from mcp.server.fastmcp import FastMCP
 from mcp.server.sse import SseServerTransport
+from pydantic import AliasChoices, Field
 from qdrant_client import models as qdrant_models
 
 # Load environment variables
@@ -58,8 +60,18 @@ mcp_router = APIRouter(prefix="/mcp")
 # Initialize SSE transport
 sse = SseServerTransport("/mcp/messages/")
 
-@mcp.tool(description="Add a new memory. This method is called everytime the user informs anything about themselves, their preferences, or anything that has any relevant information which can be useful in the future conversation. This can also be called when the user asks you to remember something.")
-async def add_memories(text: str) -> str:
+@mcp.tool(
+    description=(
+        "Add a new memory. This method is called everytime the user informs anything "
+        "about themselves, their preferences, or anything that has any relevant "
+        "information which can be useful in the future conversation. This can also be "
+        "called when the user asks you to remember something."
+    )
+)
+async def add_memories(
+    text: Annotated[str, Field(validation_alias=AliasChoices("text", "memory"))]
+) -> str:
+    """Create a new memory, accepting either `text` or legacy `memory` field."""
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
 

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -20,7 +20,7 @@ from app.utils.permissions import check_memory_access_permissions
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate as sqlalchemy_paginate
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
@@ -201,10 +201,19 @@ async def get_categories(
 
 class CreateMemoryRequest(BaseModel):
     user_id: str
-    text: str
+    text: Optional[str] = None
+    memory: Optional[str] = None
     metadata: dict = {}
     infer: bool = True
     app: str = "openmemory"
+
+    @root_validator(pre=True)
+    def populate_text(cls, values):
+        text = values.get("text") or values.get("memory")
+        if text is None:
+            raise ValueError("Either 'text' or 'memory' field is required")
+        values["text"] = text
+        return values
 
 
 # Create new memory


### PR DESCRIPTION
## Summary
- allow `memory` field as alias for `text` when creating memories
- make MCP `add_memories` tool accept either `text` or `memory`

## Testing
- `pytest` *(fails: 102 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a2229e629c832dbfa569d8462684ee